### PR TITLE
Add back https settings and rules

### DIFF
--- a/action-groups.tf
+++ b/action-groups.tf
@@ -85,6 +85,7 @@ module "cmc-doc-mgt-failure-action-group" {
   email_receiver_name    = "Document Management Failure Alerts"
   email_receiver_address = "${data.azurerm_key_vault_secret.doc_mgt_email_secret.value}"
 }
+
 output "doc_mgmt_failure_action_group_name" {
   value = "${module.cmc-doc-mgt-failure-action-group.action_group_name}"
 }

--- a/alerts.tf
+++ b/alerts.tf
@@ -1,11 +1,12 @@
 module "cmc-doc-mgt-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
-  alert_name                 = "cmc-doc-mgt-fail-alert"
-  alert_desc                 = "Triggers when a Document Management upload or download failure event is received from CMC in a 5 minute poll."
-  app_insights_query         = <<AIQ
+  alert_name = "cmc-doc-mgt-fail-alert"
+  alert_desc = "Triggers when a Document Management upload or download failure event is received from CMC in a 5 minute poll."
+
+  app_insights_query = <<AIQ
 customEvents
 | where name == "Document management upload - failure" or name == "Document management download - failure"
 AIQ
@@ -21,7 +22,7 @@ AIQ
 }
 
 module "cmc-bulk-print-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
@@ -39,7 +40,7 @@ module "cmc-bulk-print-fail-alert" {
 }
 
 module "cmc-pdf-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
@@ -67,7 +68,7 @@ AIQ
 }
 
 module "cmc-ff4j-admissions-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 

--- a/alerts.tf
+++ b/alerts.tf
@@ -1,5 +1,5 @@
 module "cmc-doc-mgt-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
@@ -22,7 +22,7 @@ AIQ
 }
 
 module "cmc-bulk-print-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
@@ -40,7 +40,7 @@ module "cmc-bulk-print-fail-alert" {
 }
 
 module "cmc-pdf-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
@@ -68,7 +68,7 @@ AIQ
 }
 
 module "cmc-ff4j-admissions-fail-alert" {
-  source            = "git@github.com:hmcts/cnp-module-metric-alert"
+  source            = "git@github.com:hmcts/cnp-module-metric-alert?ref=custom-alert-name"
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 

--- a/appgw.tf
+++ b/appgw.tf
@@ -15,15 +15,15 @@ locals {
 
 //APPLICATION GATEWAY RESOURCE FOR ENV=A
 module "appGwSouth" {
-  source            = "git@github.com:hmcts/cnp-module-waf?ref=master"
-  env               = "${var.env}"
-  subscription      = "${var.subscription}"
-  location          = "${var.location}"
-  wafName           = "${var.product}"
-  resourcegroupname = "${azurerm_resource_group.rg.name}"
-  common_tags       = "${var.common_tags}"
-  use_authentication_cert = true  
-  
+  source                  = "git@github.com:hmcts/cnp-module-waf?ref=master"
+  env                     = "${var.env}"
+  subscription            = "${var.subscription}"
+  location                = "${var.location}"
+  wafName                 = "${var.product}"
+  resourcegroupname       = "${azurerm_resource_group.rg.name}"
+  common_tags             = "${var.common_tags}"
+  use_authentication_cert = true
+
   # vNet connections
   gatewayIpConfigurations = [
     {

--- a/appgw.tf
+++ b/appgw.tf
@@ -117,7 +117,6 @@ module "appGwSouth" {
       probeEnabled                   = "True"
       probe                          = "citizen-https-probe"
       PickHostNameFromBackendAddress = "True"
-      HostName                       = ""
     },
     {
       name                           = "legal-backend-80"
@@ -139,7 +138,6 @@ module "appGwSouth" {
       probeEnabled                   = "True"
       probe                          = "legal-https-probe"
       PickHostNameFromBackendAddress = "True"
-      HostName                       = ""
     },
   ]
 
@@ -201,7 +199,7 @@ module "appGwSouth" {
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "citizen-backend-443"
       host                                = "${local.paybubble_backend_hostname}"
-      healthyStatusCodes                  = "200-404"                             // MS returns 404 on /, allowing more codes in case they change it
+      healthyStatusCodes                  = "200"
     },
     {
       # Legal
@@ -226,7 +224,7 @@ module "appGwSouth" {
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "legal-backend-443"
       host                                = "${local.paybubble_backend_hostname}"
-      healthyStatusCodes                  = "200-404"                             // MS returns 404 on /, allowing more codes in case they change it
+      healthyStatusCodes                  = "200"
     },
   ]
 }

--- a/appgw.tf
+++ b/appgw.tf
@@ -22,7 +22,8 @@ module "appGwSouth" {
   wafName           = "${var.product}"
   resourcegroupname = "${azurerm_resource_group.rg.name}"
   common_tags       = "${var.common_tags}"
-
+  use_authentication_cert = true  
+  
   # vNet connections
   gatewayIpConfigurations = [
     {

--- a/appgw.tf
+++ b/appgw.tf
@@ -198,7 +198,7 @@ module "appGwSouth" {
       unhealthyThreshold                  = 5
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "citizen-backend-443"
-      host                                = "${local.paybubble_backend_hostname}"
+      host                                = "${var.citizen_external_hostname}"
       healthyStatusCodes                  = "200"
     },
     {
@@ -223,7 +223,7 @@ module "appGwSouth" {
       unhealthyThreshold                  = 5
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "legal-backend-443"
-      host                                = "${local.paybubble_backend_hostname}"
+      host                                = "${var.legal_external_hostnamee}"
       healthyStatusCodes                  = "200"
     },
   ]

--- a/appgw.tf
+++ b/appgw.tf
@@ -108,6 +108,17 @@ module "appGwSouth" {
       HostName                       = ""
     },
     {
+      name                           = "citizen-backend-443"
+      port                           = 443
+      Protocol                       = "Https"
+      CookieBasedAffinity            = "Disabled"
+      AuthenticationCertificates     = "ilbCert"
+      probeEnabled                   = "True"
+      probe                          = "citizen-https-probe"
+      PickHostNameFromBackendAddress = "True"
+      HostName                       = ""
+    },
+    {
       name                           = "legal-backend-80"
       port                           = 80
       Protocol                       = "Http"
@@ -116,6 +127,17 @@ module "appGwSouth" {
       probeEnabled                   = "True"
       probe                          = "legal-http-probe"
       PickHostNameFromBackendAddress = "False"
+      HostName                       = ""
+    },
+    {
+      name                           = "legal-backend-443"
+      port                           = 443
+      Protocol                       = "Https"
+      CookieBasedAffinity            = "Disabled"
+      AuthenticationCertificates     = "ilbCert"
+      probeEnabled                   = "True"
+      probe                          = "legal-https-probe"
+      PickHostNameFromBackendAddress = "True"
       HostName                       = ""
     },
   ]
@@ -135,7 +157,7 @@ module "appGwSouth" {
       RuleType            = "Basic"
       httpListener        = "citizen-https-listener"
       backendAddressPool  = "${var.product}-${var.env}"
-      backendHttpSettings = "citizen-backend-80"
+      backendHttpSettings = "citizen-backend-443"
     },
     {
       # Legal
@@ -150,7 +172,7 @@ module "appGwSouth" {
       RuleType            = "Basic"
       httpListener        = "legal-https-listener"
       backendAddressPool  = "${var.product}-${var.env}"
-      backendHttpSettings = "legal-backend-80"
+      backendHttpSettings = "legal-backend-443"
     },
   ]
 
@@ -169,6 +191,18 @@ module "appGwSouth" {
       healthyStatusCodes                  = "200-399"
     },
     {
+      name                                = "citizen-https-probe"
+      protocol                            = "Https"
+      path                                = "${var.health_check}"
+      interval                            = 30
+      timeout                             = 30
+      unhealthyThreshold                  = 5
+      pickHostNameFromBackendHttpSettings = "false"
+      backendHttpSettings                 = "citizen-backend-443"
+      host                                = "${local.paybubble_backend_hostname}"
+      healthyStatusCodes                  = "200-404"                             // MS returns 404 on /, allowing more codes in case they change it
+    },
+    {
       # Legal
       name                                = "legal-http-probe"
       protocol                            = "Http"
@@ -180,6 +214,18 @@ module "appGwSouth" {
       backendHttpSettings                 = "legal-backend-80"
       host                                = "${var.legal_external_hostname}"
       healthyStatusCodes                  = "200-399"
+    },
+    {
+      name                                = "legal-https-probe"
+      protocol                            = "Https"
+      path                                = "${var.health_check}"
+      interval                            = 30
+      timeout                             = 30
+      unhealthyThreshold                  = 5
+      pickHostNameFromBackendHttpSettings = "false"
+      backendHttpSettings                 = "legal-backend-443"
+      host                                = "${local.paybubble_backend_hostname}"
+      healthyStatusCodes                  = "200-404"                             // MS returns 404 on /, allowing more codes in case they change it
     },
   ]
 }


### PR DESCRIPTION
Access via https://moneyclaims.aat.platform.hmcts.net/ still not working. DNS has been updated. Thinking about this... we surely do need the https settings. The app service is set to https only so this will redirect back to app gw and not work. Or am I missing something here? 