### PR TITLE
Add empty HostName to 443 settings

### DIFF
--- a/appgw.tf
+++ b/appgw.tf
@@ -117,6 +117,7 @@ module "appGwSouth" {
       probeEnabled                   = "True"
       probe                          = "citizen-https-probe"
       PickHostNameFromBackendAddress = "True"
+      HostName                       = ""
     },
     {
       name                           = "legal-backend-80"
@@ -138,6 +139,7 @@ module "appGwSouth" {
       probeEnabled                   = "True"
       probe                          = "legal-https-probe"
       PickHostNameFromBackendAddress = "True"
+      HostName                       = ""
     },
   ]
 


### PR DESCRIPTION
I thought this could be dropped (readme in waf module)

```
* azurerm_template_deployment.waf: Error waiting for deployment: Code="DeploymentFailed" Message="At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details." Details=[{"code":"Conflict","message":"{\r\n  \"status\": \"Failed\",\r\n  \"error\": {\r\n    \"code\": \"ResourceDeploymentFailure\",\r\n    \"message\": \"The resource operation completed with terminal provisioning state 'Failed'.\",\r\n    \"details\": [\r\n      {\r\n        \"code\": \"DeploymentFailed\",\r\n        \"message\": \"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details.\",\r\n        \"details\": [\r\n          {\r\n            \"code\": \"BadRequest\",\r\n            \"message\": \"{\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"InvalidTemplate\\\",\\r\\n    \\\"message\\\": \\\"Deployment template validation failed: 'The template variable 'request_forwarding_properties' is not valid: The language expression property 'HostName' doesn't exist, available properties are 'AuthenticationCertificates, CookieBasedAffinity, PickHostNameFromBackendAddress, Protocol, name, port, probe, probeEnabled'.. Please see https://aka.ms/arm-template-expressions for usage details.'.\\\"\\r\\n  }\\r\\n}\"\r\n          }\r\n        ]\r\n      }\r\n    ]\r\n  }\r\n}"}]
```