### PR TITLE
ROC-5259: change healthyStatusCodes = 200-399 (idam redirect)

### DIFF
--- a/appgw.tf
+++ b/appgw.tf
@@ -201,7 +201,7 @@ module "appGwSouth" {
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "citizen-backend-443"
       host                                = "${var.citizen_external_hostname}"
-      healthyStatusCodes                  = "200"
+      healthyStatusCodes                  = "200-399"
     },
     {
       # Legal
@@ -226,7 +226,7 @@ module "appGwSouth" {
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "legal-backend-443"
       host                                = "${var.legal_external_hostname}"
-      healthyStatusCodes                  = "200"
+      healthyStatusCodes                  = "200-399"
     },
   ]
 }


### PR DESCRIPTION
Application gateways reporting unhealthy backends because response code of 302 (when redirecting to IDAM www) is not configured as a healthy response. 