### PR TITLE
ROC-5259: Drop https probe

### DIFF
--- a/appgw.tf
+++ b/appgw.tf
@@ -192,18 +192,6 @@ module "appGwSouth" {
       healthyStatusCodes                  = "200-399"
     },
     {
-      name                                = "citizen-https-probe"
-      protocol                            = "Https"
-      path                                = "/"
-      interval                            = 30
-      timeout                             = 30
-      unhealthyThreshold                  = 5
-      pickHostNameFromBackendHttpSettings = "false"
-      backendHttpSettings                 = "citizen-backend-443"
-      host                                = "${var.citizen_external_hostname}"
-      healthyStatusCodes                  = "200-399"
-    },
-    {
       # Legal
       name                                = "legal-http-probe"
       protocol                            = "Http"
@@ -213,18 +201,6 @@ module "appGwSouth" {
       unhealthyThreshold                  = 5
       pickHostNameFromBackendHttpSettings = "false"
       backendHttpSettings                 = "legal-backend-80"
-      host                                = "${var.legal_external_hostname}"
-      healthyStatusCodes                  = "200-399"
-    },
-    {
-      name                                = "legal-https-probe"
-      protocol                            = "Https"
-      path                                = "/"
-      interval                            = 30
-      timeout                             = 30
-      unhealthyThreshold                  = 5
-      pickHostNameFromBackendHttpSettings = "false"
-      backendHttpSettings                 = "legal-backend-443"
       host                                = "${var.legal_external_hostname}"
       healthyStatusCodes                  = "200-399"
     },


### PR DESCRIPTION
HTTPS probe wasn't there before and not configured for most other services. 

I am a little confused but this will get all envs back to a working state and i can investigate a bit in sandbox isolation.